### PR TITLE
Add mouse support to TerminalRenderer

### DIFF
--- a/Sources/SwiftTUI/Controls/Control.swift
+++ b/Sources/SwiftTUI/Controls/Control.swift
@@ -110,6 +110,21 @@ public class Control: LayoutObject {
     public func selectableElement(rightOf index: Int) -> Control? { parent?.selectableElement(rightOf: self.index) }
     public func selectableElement(leftOf index: Int) -> Control? { parent?.selectableElement(leftOf: self.index) }
 
+    public func selectableElement(at position: Position) -> Control? {
+        if layer.frame.contains(position) {
+            let localPosition = position - layer.frame.position
+            for child in children.reversed() {
+                if let found = child.selectableElement(at: localPosition) {
+                    return found
+                }
+            }
+            if selectable {
+                return self
+            }
+        }
+        return nil
+    }
+
     // MARK: - Scrolling
 
     func scroll(to position: Position) {

--- a/Sources/SwiftTUI/RunLoop/ASCII.swift
+++ b/Sources/SwiftTUI/RunLoop/ASCII.swift
@@ -3,4 +3,5 @@ import Foundation
 public enum ASCII {
     public static let EOT: Character = "\u{04}"
     public static let DEL: Character = "\u{7f}"
+    public static let ESC: Character = "\u{1B}"
 }

--- a/Sources/SwiftTUI/Terminal/Drawing/EscapeSequence.swift
+++ b/Sources/SwiftTUI/Terminal/Drawing/EscapeSequence.swift
@@ -51,4 +51,13 @@ enum EscapeSequence {
 
     static let enableInverted = "\u{1b}[7m"
     static let disableInverted = "\u{1b}[27m"
+
+    static let enableBasicMouseTracking = "\u{1B}[?1000h"
+    static let disableBasicMouseTracking = "\u{1B}[?1000l"
+
+    static let enableButtonCellMouseTracking = "\u{1B}[?1002h"
+    static let disableButtonCellMouseTracking = "\u{1B}[?1002l"
+
+    static let enableSGRExtendedMouseMode = "\u{1B}[?1006h"
+    static let disableSGRExtendedMouseMode = "\u{1B}[?1006l"
 }

--- a/Sources/SwiftTUI/Terminal/Input/MouseEventParser.swift
+++ b/Sources/SwiftTUI/Terminal/Input/MouseEventParser.swift
@@ -16,13 +16,12 @@ class MouseEventParser {
     }
     
     enum ParserState {
-        case none
-        case esc
-        case csi
-        case parameters(String)
+        case esc // escape character detected (ESC)
+        case csi // Control Sequence Introducer detected (ESC[)
+        case parameters(String) // collecting parameters
     }
 
-    var state: ParserState = .none
+    var state: ParserState? = .none
     var mouseEvent: MouseEvent?
 
     func parse(character: Character) -> Bool {
@@ -33,6 +32,7 @@ class MouseEventParser {
                 return true
             }
             return false
+
         case .esc:
             if character == "[" {
                 state = .csi
@@ -41,6 +41,7 @@ class MouseEventParser {
                 state = .none
                 return false
             }
+        
         case .csi:
             if character == "M" || character == "<" {
                 state = .parameters("")
@@ -49,6 +50,7 @@ class MouseEventParser {
                 state = .none
                 return false
             }
+        
         case .parameters(let params):
             if character.isNumber || character == ";" || character == "m" || character == "M" || character == "<" || character == "-" {
                 let newParams = params + String(character)
@@ -82,4 +84,3 @@ class MouseEventParser {
         }
     }
 }
-

--- a/Sources/SwiftTUI/Terminal/Input/MouseEventParser.swift
+++ b/Sources/SwiftTUI/Terminal/Input/MouseEventParser.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+class MouseEventParser {
+    struct MouseEvent {
+        enum EventType {
+            case press
+            case release
+            case wheel
+            case move
+        }
+
+        let eventType: EventType
+        let button: Int
+        let column: Int
+        let row: Int
+    }
+    
+    enum ParserState {
+        case none
+        case esc
+        case csi
+        case parameters(String)
+    }
+
+    var state: ParserState = .none
+    var mouseEvent: MouseEvent?
+
+    func parse(character: Character) -> Bool {
+        switch state {
+        case .none:
+            if character == ASCII.ESC {
+                state = .esc
+                return true
+            }
+            return false
+        case .esc:
+            if character == "[" {
+                state = .csi
+                return true
+            } else {
+                state = .none
+                return false
+            }
+        case .csi:
+            if character == "M" || character == "<" {
+                state = .parameters("")
+                return true
+            } else {
+                state = .none
+                return false
+            }
+        case .parameters(let params):
+            if character.isNumber || character == ";" || character == "m" || character == "M" || character == "<" || character == "-" {
+                let newParams = params + String(character)
+                if character == "M" || character == "m" {
+                    // End of mouse event sequence
+                    parseMouseEvent(parameters: newParams)
+                    state = .none
+                    return true
+                } else {
+                    state = .parameters(newParams)
+                    return true
+                }
+            } else {
+                state = .none
+                return false
+            }
+        }
+    }
+
+    private func parseMouseEvent(parameters: String) {
+        // Example parameters: "<0;15;10M" or "<35;15;10m"
+        let cleanedParams = parameters.trimmingCharacters(in: CharacterSet(charactersIn: "<>"))
+        let components = cleanedParams.components(separatedBy: [";", "M", "m"]).filter { !$0.isEmpty }
+
+        if components.count >= 3,
+           let cb = Int(components[0]),
+           let x = Int(components[1]),
+           let y = Int(components[2]) {
+            let eventType: MouseEvent.EventType = (parameters.last == "M") ? .press : .release
+            mouseEvent = MouseEvent(eventType: eventType, button: cb, column: x, row: y)
+        }
+    }
+}
+

--- a/Sources/SwiftTUI/Terminal/Input/TerminalInputHandler.swift
+++ b/Sources/SwiftTUI/Terminal/Input/TerminalInputHandler.swift
@@ -43,15 +43,15 @@ public class TerminalInputHandler: InputHandler {
     }
 
     private func enableMouseTracking() {
-        write("\u{1B}[?1000h") // Enable mouse tracking (basic mode)
-        write("\u{1B}[?1002h") // Enable button-cell mouse tracking
-        write("\u{1B}[?1006h") // Enable SGR extended mouse mode
+        write(EscapeSequence.enableBasicMouseTracking)
+        write(EscapeSequence.enableButtonCellMouseTracking)
+        write(EscapeSequence.enableSGRExtendedMouseMode)
     }
 
     private func disableMouseTracking() {
-        write("\u{1B}[?1000l")
-        write("\u{1B}[?1002l")
-        write("\u{1B}[?1006l")
+        write(EscapeSequence.disableBasicMouseTracking)
+        write(EscapeSequence.disableButtonCellMouseTracking)
+        write(EscapeSequence.disableSGRExtendedMouseMode)
     }
 
     private func setupInputHandlers() {

--- a/Sources/SwiftTUI/Terminal/Input/TerminalInputHandler.swift
+++ b/Sources/SwiftTUI/Terminal/Input/TerminalInputHandler.swift
@@ -43,15 +43,15 @@ public class TerminalInputHandler: InputHandler {
     }
 
     private func enableMouseTracking() {
-        write(EscapeSequence.enableBasicMouseTracking)
-        write(EscapeSequence.enableButtonCellMouseTracking)
-        write(EscapeSequence.enableSGRExtendedMouseMode)
+        _write(EscapeSequence.enableBasicMouseTracking)
+        _write(EscapeSequence.enableButtonCellMouseTracking)
+        _write(EscapeSequence.enableSGRExtendedMouseMode)
     }
 
     private func disableMouseTracking() {
-        write(EscapeSequence.disableBasicMouseTracking)
-        write(EscapeSequence.disableButtonCellMouseTracking)
-        write(EscapeSequence.disableSGRExtendedMouseMode)
+        _write(EscapeSequence.disableBasicMouseTracking)
+        _write(EscapeSequence.disableButtonCellMouseTracking)
+        _write(EscapeSequence.disableSGRExtendedMouseMode)
     }
 
     private func setupInputHandlers() {
@@ -207,7 +207,7 @@ public class TerminalInputHandler: InputHandler {
         application?.stop()
     }
 
-    private func write(_ str: String) {
-        str.withCString { _ = Darwin.write(STDOUT_FILENO, $0, strlen($0)) }
+    private func _write(_ str: String) {
+        str.withCString { _ = write(STDOUT_FILENO, $0, strlen($0)) }
     }
 }


### PR DESCRIPTION
I tried to not introduce new abstractions to the _core framework_. Yet, it required a new `Control.selectableElement(at:)` method.

**Key changes:**

- Mouse input is captured alongside keyboard events.
- The _selectable_ control at the mouse event position is identified, then:
    * any mouse event makes the control become _first responder_;
    * the release of any mouse button sends a _new line_ character if the control is a `ButtonControl`.

Only tested on macOS 14.6.1 - Xcode 15.4 (15F31d)

**EDIT:** Tested also on Linux with official Docker image. On Windows it won't build (see #4).