### PR TITLE
Add Image view

### DIFF
--- a/Sources/SwiftTUI/Drawing/Cell+fromPixelBlock.swift
+++ b/Sources/SwiftTUI/Drawing/Cell+fromPixelBlock.swift
@@ -1,0 +1,279 @@
+import Foundation
+
+extension Cell {
+    typealias ColorChannels = (Int, Int, Int)
+
+    /// Builds a `Cell` object that represents the contents of the given _pixel block_ in the given color mode.
+    /// Based on Stefan Haustein's `TerminalImageViewer.java` -- original license: Apache 2.0.
+    static func fromPixelBlock(_ pixels: Image.PixelBlock, colorMode: ColorMode) -> Cell {
+        // Initialize min and max arrays
+        let height = pixels.count
+        let width = pixels[0].count
+
+        assert(height == Image.pixelBlockSize.height)
+        assert(width == Image.pixelBlockSize.width)
+
+        // Determine min and max for each color channel
+        let (minColor, maxColor) = colorRange(pixels)
+
+        // Determine the channel with the greatest range
+        let (splitIndex, bestSplit) = greatestRangeChannel(minColor: minColor, maxColor: maxColor)
+        
+        // Compute the split value
+        let splitValue = minColor[splitIndex] + bestSplit / 2
+        
+        // Compute average colors and bitmap
+        var (fgChannels, fgCount, bgChannels, _, bits) = averageColors(pixels: pixels, splitIndex: splitIndex, splitValue: splitValue)
+        
+        // After computing fgColor and bgColor, find best matching character
+        let bestChar = bestMatchingCharacter(
+            bits: bits,
+            width: width,
+            height: height,
+            fgCount: fgCount,
+            fgChannels: &fgChannels,
+            bgChannels: &bgChannels,
+            colorMode: colorMode
+        )
+        
+        // Create Colors based on the color mode
+        let (fgColor, bgColor) = buildColor(fgChannels: fgChannels, bgChannels: bgChannels, colorMode: colorMode)
+        
+        // Create a Cell
+        return Cell(
+            char: bestChar,
+            foregroundColor: fgColor,
+            backgroundColor: bgColor,
+            attributes: CellAttributes()
+        )
+    }
+    
+    /// Helper function to compute xterm 256-color value
+    private static func xterm256ColorValue(r: Int, g: Int, b: Int) -> Int {
+        let rValue = r * 5 / 255
+        let gValue = g * 5 / 255
+        let bValue = b * 5 / 255
+        return 16 + 36 * rValue + 6 * gValue + bValue
+    }
+    
+    private static func toGrayscale(_ color: ColorChannels) -> ColorChannels {
+        let gray = Int(0.299 * Double(color.0) + 0.587 * Double(color.1) + 0.114 * Double(color.2))
+        return (gray, gray, gray)
+    }
+    
+    private static func to256Color(_ color: ColorChannels) -> ColorChannels {
+        let r = color.0 * 5 / 255
+        let g = color.1 * 5 / 255
+        let b = color.2 * 5 / 255
+        let mappedColor = (
+            r * 255 / 5,
+            g * 255 / 5,
+            b * 255 / 5
+        )
+        return mappedColor
+    }
+    
+    private static func hammingDistance(_ a: Image.PixelBlockBitmap, _ b: Image.PixelBlockBitmap) -> Int {
+        let xor = a ^ b
+        return xor.nonzeroBitCount
+    }
+    
+    private static func colorRange(_ pixels: Image.PixelBlock) -> (min:[Int], max:[Int]) {
+        // Initialize min and max arrays
+        var minColor = [255, 255, 255]
+        var maxColor = [0, 0, 0]
+
+        // Determine min and max for each color channel
+        for row in pixels {
+            for pixel in row {
+                for i in 0..<3 {
+                    let value = pixel[i]
+                    if value < minColor[i] {
+                        minColor[i] = value
+                    }
+                    if value > maxColor[i] {
+                        maxColor[i] = value
+                    }
+                }
+            }
+        }
+        
+        return (min: minColor, max: maxColor)
+    }
+    
+    private static func greatestRangeChannel(minColor: [Int], maxColor: [Int]) -> (index: Int, range: Int) {
+        var splitIndex = 0
+        var bestSplit = 0
+        for i in 0..<3 {
+            let range = maxColor[i] - minColor[i]
+            if range > bestSplit {
+                bestSplit = range
+                splitIndex = i
+            }
+        }
+        return (index: splitIndex, range: bestSplit)
+    }
+    
+    private static func averageColors(
+        pixels: Image.PixelBlock,
+        splitIndex: Int,
+        splitValue: Int
+    ) -> (foreground: ColorChannels, foregroundCount: Int, background: ColorChannels, backgroundCount: Int, bits: Image.PixelBlockBitmap) {
+        // Initialize the bits, foreground and background colors
+        var bits: Image.PixelBlockBitmap = 0
+        var fgColorSum = [0, 0, 0]
+        var bgColorSum = [0, 0, 0]
+        var fgCount = 0
+        var bgCount = 0
+        
+        // Assign pixels to foreground or background and build the bits
+        for row in pixels {
+            for pixel in row {
+                bits <<= 1
+                let value = pixel[splitIndex]
+                if value > splitValue {
+                    // Foreground
+                    bits |= 1
+                    for i in 0..<3 {
+                        fgColorSum[i] += pixel[i]
+                    }
+                    fgCount += 1
+                } else {
+                    // Background
+                    for i in 0..<3 {
+                        bgColorSum[i] += pixel[i]
+                    }
+                    bgCount += 1
+                }
+            }
+        }
+        
+        // Compute average colors
+        if fgCount > 0 {
+            for i in 0..<3 {
+                fgColorSum[i] /= fgCount
+            }
+        }
+        if bgCount > 0 {
+            for i in 0..<3 {
+                bgColorSum[i] /= bgCount
+            }
+        }
+        
+        // Foreground and background colors
+        let fgChannels = (fgColorSum[0], fgColorSum[1], fgColorSum[2])
+        let bgChannels = (bgColorSum[0], bgColorSum[1], bgColorSum[2])
+        
+        return (
+            foreground: fgChannels,
+            foregroundCount: fgCount,
+            background: bgChannels,
+            backgroundCount: bgCount,
+            bits: bits
+        )
+    }
+    
+    private static func bestMatchingCharacter(
+        bits: Image.PixelBlockBitmap,
+        width: Int,
+        height: Int,
+        fgCount: Int,
+        fgChannels: inout ColorChannels,
+        bgChannels: inout ColorChannels,
+        colorMode: ColorMode
+    ) -> Character {
+        // Adjust fgColor and bgColor based on the color mode
+        switch colorMode {
+        case .grayscale:
+            fgChannels = toGrayscale(fgChannels)
+            bgChannels = toGrayscale(bgChannels)
+        case .color256:
+            fgChannels = to256Color(fgChannels)
+            bgChannels = to256Color(bgChannels)
+        case .trueColor:
+            // No adjustment needed
+            break
+        }
+        
+        // Now, find the best matching character
+        var bestDiff = Int.max
+        var bestChar: Character = " "
+        var invert = false
+        
+        for (bitmap, char) in Character.bitmaps {
+            let diff = hammingDistance(bits, bitmap)
+            if diff < bestDiff {
+                bestDiff = diff
+                bestChar = char
+                invert = false
+            }
+            let invertedBitmap = ~bitmap
+            let diffInverted = hammingDistance(bits, invertedBitmap)
+            if diffInverted < bestDiff {
+                bestDiff = diffInverted
+                bestChar = char
+                invert = true
+            }
+        }
+        
+        // If the match is quite bad, use a shade character instead
+        if bestDiff > 10 {
+            invert = false
+            let totalPixels = width * height
+            let index = min(4, fgCount * 5 / totalPixels)
+            let shadeChars = [" ", "\u{2591}", "\u{2592}", "\u{2593}", "\u{2588}"]
+            bestChar = Character(shadeChars[index])
+        }
+        
+        // If we use an inverted character, swap fg and bg colors
+        if invert {
+            swap(&fgChannels, &bgChannels)
+        }
+        
+        return bestChar
+    }
+    
+    private static func buildColor(
+        fgChannels: ColorChannels,
+        bgChannels: ColorChannels,
+        colorMode: ColorMode
+    ) -> (foreground: Color, background: Color) {
+        switch colorMode {
+        case .grayscale:
+            let grayValueFG = fgChannels.0 * 23 / 255  // Map 0-255 to 0-23
+            let grayValueBG = bgChannels.0 * 23 / 255
+            return (
+                foreground: Color.xterm(white: grayValueFG),
+                background: Color.xterm(white: grayValueBG)
+            )
+            
+        case .color256:
+            let colorValueFG = xterm256ColorValue(r: fgChannels.0, g: fgChannels.1, b: fgChannels.2)
+            let colorValueBG = xterm256ColorValue(r: bgChannels.0, g: bgChannels.1, b: bgChannels.2)
+            return (
+                foreground: Color.xtermColor(value: colorValueFG),
+                background: Color.xtermColor(value: colorValueBG)
+            )
+            
+        case .trueColor:
+            return (
+                foreground: Color.trueColor(red: fgChannels.0, green: fgChannels.1, blue: fgChannels.2),
+                background: Color.trueColor(red: bgChannels.0, green: bgChannels.1, blue: bgChannels.2)
+            )
+        }
+    }
+}
+
+extension TrueColor {
+    fileprivate subscript(_ channel: Int) -> Int {
+        if channel == 0 {
+            return red
+        } else if channel == 1 {
+            return green
+        } else if channel == 2 {
+            return blue
+        } else {
+            fatalError("Invalid color channel: \(channel)")
+        }
+    }
+}

--- a/Sources/SwiftTUI/Drawing/Character+bitmaps.swift
+++ b/Sources/SwiftTUI/Drawing/Character+bitmaps.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+extension Character {
+    /// _Pixel block bitmap to character mapping.
+    /// Based on Stefan Haustein's `TerminalImageViewer.java` -- original license: Apache 2.0.
+    static let bitmaps: [(Image.PixelBlockBitmap, Character)] = [
+        (0x00000000, "\u{00a0}"),
+        
+        // Block graphics
+        
+        //0xffff0000, "\u{2580}",  // upper 1/2; redundant with inverse lower 1/2
+
+        (0x0000000f, "\u{2581}"),  // lower 1/8
+        (0x000000ff, "\u{2582}"),  // lower 1/4
+        (0x00000fff, "\u{2583}"),
+        (0x0000ffff, "\u{2584}"),  // lower 1/2
+        (0x000fffff, "\u{2585}"),
+        (0x00ffffff, "\u{2586}"),  // lower 3/4
+        (0x0fffffff, "\u{2587}"),
+        //(0xffffffff, "\u{2588}"),  // full; redundant with inverse space
+        
+        (0xeeeeeeee, "\u{258a}"),  // left 3/4
+        (0xcccccccc, "\u{258c}"),  // left 1/2
+        (0x88888888, "\u{258e}"),  // left 1/4
+        
+        (0x0000cccc, "\u{2596}"),  // quadrant lower left
+        (0x00003333, "\u{2597}"),  // quadrant lower right
+        (0xcccc0000, "\u{2598}"),  // quadrant upper left
+        //(0xccccffff, "\u{2599}"),  // 3/4 redundant with inverse 1/4
+        (0xcccc3333, "\u{259a}"),  // diagonal 1/2
+        //(0xffffcccc, "\u{259b}"),  // 3/4 redundant
+        //(0xffff3333, "\u{259c}"),  // 3/4 redundant
+        (0x33330000, "\u{259d}"),  // quadrant upper right
+        //(0x3333cccc, "\u{259e}"),  // 3/4 redundant
+        //(0x3333ffff, "\u{259f}"),  // 3/4 redundant
+        
+        // Line drawing subset: no double lines, no complex light lines
+        // Simple light lines duplicated because there is no center pixel int the 4x8 matrix
+        
+        (0x000ff000, "\u{2501}"),  // Heavy horizontal
+        (0x66666666, "\u{2503}"),  // Heavy vertical
+        
+        (0x00077666, "\u{250f}"),  // Heavy down and right
+        (0x000ee666, "\u{2513}"),  // Heavy down and left
+        (0x66677000, "\u{2517}"),  // Heavy up and right
+        (0x666ee000, "\u{251b}"),  // Heavy up and left
+        
+        (0x66677666, "\u{2523}"),  // Heavy vertical and right
+        (0x666ee666, "\u{252b}"),  // Heavy vertical and left
+        (0x000ff666, "\u{2533}"),  // Heavy down and horizontal
+        (0x666ff000, "\u{253b}"),  // Heavy up and horizontal
+        (0x666ff666, "\u{254b}"),  // Heavy cross
+        
+        (0x000cc000, "\u{2578}"),  // Bold horizontal left
+        (0x00066000, "\u{2579}"),  // Bold horizontal up
+        (0x00033000, "\u{257a}"),  // Bold horizontal right
+        (0x00066000, "\u{257b}"),  // Bold horizontal down
+        
+        (0x06600660, "\u{254f}"),  // Heavy double dash vertical
+        
+        (0x000f0000, "\u{2500}"),  // Light horizontal
+        (0x0000f000, "\u{2500}"),  //
+        (0x44444444, "\u{2502}"),  // Light vertical
+        (0x22222222, "\u{2502}"),
+        
+        (0x000e0000, "\u{2574}"),  // light left
+        (0x0000e000, "\u{2574}"),  // light left
+        (0x44440000, "\u{2575}"),  // light up
+        (0x22220000, "\u{2575}"),  // light up
+        (0x00030000, "\u{2576}"),  // light right
+        (0x00003000, "\u{2576}"),  // light right
+        (0x00004444, "\u{2575}"),  // light down
+        (0x00002222, "\u{2575}"),  // light down
+        
+        // Misc technical
+        
+        (0x44444444, "\u{23a2}"),  // [ extension
+        (0x22222222, "\u{23a5}"),  // ] extension
+        
+        (0x0f000000, "\u{23ba}"),  // Horizontal scanline 1
+        (0x00f00000, "\u{23bb}"),  // Horizontal scanline 3
+        (0x00000f00, "\u{23bc}"),  // Horizontal scanline 7
+        (0x000000f0, "\u{23bd}"),  // Horizontal scanline 9
+        
+        // Geometrical shapes.
+
+        (0x00066000, "\u{25aa}"),  // Black small square
+    ]
+}

--- a/Sources/SwiftTUI/Drawing/Color.swift
+++ b/Sources/SwiftTUI/Drawing/Color.swift
@@ -41,6 +41,10 @@ public struct Color: Hashable {
         Color(data: .trueColor(TrueColor(red: red, green: green, blue: blue)))
     }
 
+    public static func xtermColor(value: Int) -> Color {
+        Color(data: .xterm(XTermColor(value: value)))
+    }
+    
     var foregroundEscapeSequence: String {
         switch data {
         case .ansi(let color):
@@ -124,7 +128,7 @@ struct XTermColor: Hashable {
 
     static func grayscale(white: Int) -> XTermColor {
         guard white >= 0, white < 24 else {
-            fatalError("Color value must lie between 1 and 24")
+            fatalError("Color value must lie between 0 and 23")
         }
         let offset = 16 + (6 * 6 * 6)
         return XTermColor(value: offset + white)

--- a/Sources/SwiftTUI/Drawing/PortablePixmapParser.swift
+++ b/Sources/SwiftTUI/Drawing/PortablePixmapParser.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+enum PortablePixmapParser {
+    enum Failure: Error {
+        case failedToReadFile
+        case unsupportedPPMFormat
+        case invalidDimensions
+        case invalidMaxColorValue
+        case notEnoughPixelData
+    }
+    
+    enum MagicNumber: String {
+        case P3 // ascii
+        case P6 // raw
+    }
+    
+    static func parse(filePath: String) throws -> Image.PixelBlock {
+        let fileData = try Data(contentsOf: URL(fileURLWithPath: filePath))
+        return try parse(data: fileData)
+    }
+    
+    static func parse(data: Data) throws -> Image.PixelBlock {
+        var offset = 0
+        let bytes = [UInt8](data)
+        
+        // Helper function to skip whitespace and comments
+        func nextToken() throws -> String {
+            var token = ""
+            while offset < bytes.count {
+                let byte = bytes[offset]
+                if byte == UInt8(ascii: "#") {
+                    // Skip the comment line
+                    while offset < bytes.count && bytes[offset] != UInt8(ascii: "\n") {
+                        offset += 1
+                    }
+                } else if byte.isWhitespaceOrNewline() {
+                    offset += 1
+                } else {
+                    // Start of a token
+                    while offset < bytes.count && !bytes[offset].isWhitespaceOrNewline() && bytes[offset] != UInt8(ascii: "#") {
+                        token.append(Character(UnicodeScalar(bytes[offset])))
+                        offset += 1
+                    }
+                    break
+                }
+            }
+            if token.isEmpty {
+                throw Failure.unsupportedPPMFormat
+            }
+            return token
+        }
+        
+        // Read magic number
+        let magicNumberStr = try nextToken()
+        guard let magicNumber = MagicNumber(rawValue: magicNumberStr) else {
+            throw Failure.unsupportedPPMFormat
+        }
+        
+        // Read width
+        let widthStr = try nextToken()
+        guard let width = Int(widthStr), width > 0 else {
+            throw Failure.invalidDimensions
+        }
+        
+        // Read height
+        let heightStr = try nextToken()
+        guard let height = Int(heightStr), height > 0 else {
+            throw Failure.invalidDimensions
+        }
+        
+        // Read max color value
+        let maxColorValueStr = try nextToken()
+        guard let maxColorValue = Int(maxColorValueStr), maxColorValue > 0 && maxColorValue <= 65535 else {
+            throw Failure.invalidMaxColorValue
+        }
+        
+        // Determine if maxColorValue is greater than 255 (for P6 binary with 16-bit color)
+        let isTwoBytesPerColor = maxColorValue > 255
+        
+        // Calculate the number of pixels
+        let expectedPixelCount = width * height
+        
+        switch magicNumber {
+        case .P3:
+            // ASCII PPM
+            // Read remaining data as a string
+            guard let remainingString = String(data: data.subdata(in: offset..<data.count), encoding: .ascii) else {
+                throw Failure.notEnoughPixelData
+            }
+            let scanner = Scanner(string: remainingString)
+            scanner.charactersToBeSkipped = CharacterSet.whitespacesAndNewlines
+            
+            var pixels: Image.PixelBlock = []
+            for _ in 0..<height {
+                var row: [TrueColor] = []
+                for _ in 0..<width {
+                    var r = 0, g = 0, b = 0
+                    if !scanner.scanInt(&r) || !scanner.scanInt(&g) || !scanner.scanInt(&b) {
+                        throw Failure.notEnoughPixelData
+                    }
+                    row.append(TrueColor(red: r, green: g, blue: b))
+                }
+                pixels.append(row)
+            }
+            return pixels
+            
+        case .P6:
+            // Binary PPM
+            // After the header, there should be one whitespace character before pixel data
+            // Ensure that the next byte is a whitespace
+            if offset < bytes.count {
+                let byte = bytes[offset]
+                if !byte.isWhitespaceOrNewline() {
+                    throw Failure.unsupportedPPMFormat
+                }
+                offset += 1 // Skip the whitespace
+            }
+            
+            // Calculate expected data size
+            let bytesPerColor = isTwoBytesPerColor ? 2 : 1
+            let expectedDataSize = expectedPixelCount * 3 * bytesPerColor
+            
+            guard offset + expectedDataSize <= bytes.count else {
+                throw Failure.notEnoughPixelData
+            }
+            
+            var pixels: Image.PixelBlock = []
+            for _ in 0..<height {
+                var row: [TrueColor] = []
+                for _ in 0..<width {
+                    var r = 0, g = 0, b = 0
+                    if isTwoBytesPerColor {
+                        // Big endian two bytes per color
+                        r = (Int(bytes[offset]) << 8) | Int(bytes[offset + 1])
+                        g = (Int(bytes[offset + 2]) << 8) | Int(bytes[offset + 3])
+                        b = (Int(bytes[offset + 4]) << 8) | Int(bytes[offset + 5])
+                        offset += 6
+                    } else {
+                        r = Int(bytes[offset])
+                        g = Int(bytes[offset + 1])
+                        b = Int(bytes[offset + 2])
+                        offset += 3
+                    }
+                    // Normalize colors to 0-255 if maxColorValue > 255
+                    if maxColorValue > 255 {
+                        r = r * 255 / maxColorValue
+                        g = g * 255 / maxColorValue
+                        b = b * 255 / maxColorValue
+                    }
+                    row.append(TrueColor(red: r, green: g, blue: b))
+                }
+                pixels.append(row)
+            }
+            return pixels
+        }
+    }
+}
+
+extension UInt8 {
+    fileprivate func isWhitespaceOrNewline() -> Bool {
+        CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(self))
+    }
+}

--- a/Sources/SwiftTUI/Views/Controls/Image.swift
+++ b/Sources/SwiftTUI/Views/Controls/Image.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+public enum ColorMode {
+    case grayscale
+    case color256
+    case trueColor
+}
+
+/// A view that displays an image.
+public struct Image: View, PrimitiveView {
+    typealias PixelBlock = [[TrueColor]]
+    typealias PixelBlockBitmap = UInt32
+
+    static let pixelBlockSize = (width: 4, height: 8)
+    
+    private var pixels: PixelBlock
+    private var colorMode: ColorMode
+
+    /// Initialize an `Image` with a PPM image `path`.
+    public init(path: String, colorMode: ColorMode = .color256) {
+        self.init(
+            try! PortablePixmapParser.parse(filePath: path),
+            colorMode: colorMode
+        )
+    }
+
+    /// Initialize an `Image` with a PPM image.
+    public init(ppm data: Data, colorMode: ColorMode = .color256) {
+        self.init(
+            try! PortablePixmapParser.parse(data: data),
+            colorMode: colorMode
+        )
+    }
+
+    init(_ pixels: PixelBlock, colorMode: ColorMode) {
+        self.pixels = pixels
+        self.colorMode = colorMode
+    }
+    
+    static var size: Int? { 1 }
+    
+    func buildNode(_ node: Node) {
+        setupEnvironmentProperties(node: node)
+        node.control = ImageControl(
+            pixels: pixels,
+            colorMode: colorMode
+        )
+    }
+    
+    func updateNode(_ node: Node) {
+        setupEnvironmentProperties(node: node)
+        node.view = self
+        let control = node.control as! ImageControl
+        control.pixels = pixels
+        control.colorMode = colorMode
+        control.layer.invalidate()
+    }
+    
+    private class ImageControl: Control {
+        var pixels: Image.PixelBlock
+        var colorMode: ColorMode
+        
+        init(
+            pixels: Image.PixelBlock,
+            colorMode: ColorMode
+        ) {
+            self.pixels = pixels
+            self.colorMode = colorMode
+        }
+        
+        override func size(proposedSize: Size) -> Size {
+            let imageHeight = pixels.count
+            guard imageHeight > 0 else {
+                return Size(width: 0, height: 0)
+            }
+            let imageWidth = pixels[0].count
+            
+            // Each terminal cell represents a pixel block
+            let width = (imageWidth + pixelBlockSize.width - 1) / pixelBlockSize.width // ceiling ensures image size will fit all pixels
+            let height = (imageHeight + pixelBlockSize.height - 1) / pixelBlockSize.height
+            return Size(width: Extended(width), height: Extended(height))
+        }
+        
+        override func cell(at position: Position) -> Cell? {
+            guard !pixels.isEmpty else {
+                return nil
+            }
+            
+            let startY = position.line.intValue * pixelBlockSize.height
+            let startX = position.column.intValue * pixelBlockSize.width
+            let height = pixels.count
+            let width = pixels[0].count
+            
+            if startY >= height || startX >= width {
+                return nil
+            }
+            
+            // Extract the block of pixels
+            var block: Image.PixelBlock = []
+            for y in startY..<min(startY + pixelBlockSize.height, height) {
+                var row: [TrueColor] = []
+                for x in startX..<min(startX + pixelBlockSize.width, width) {
+                    row.append(pixels[y][x])
+                }
+                // Pad the row to ensure it has expected columns
+                while row.count < pixelBlockSize.width {
+                    let additionalColumn = row.last ?? TrueColor(red: 0, green: 0, blue: 0)
+                    row.append(additionalColumn)
+                }
+                block.append(row)
+            }
+            
+            // Pad the block to ensure it has expected rows
+            while block.count < pixelBlockSize.height {
+                let additionalRow = block.last ?? [TrueColor](repeating: TrueColor(red: 0, green: 0, blue: 0), count: pixelBlockSize.width)
+                block.append(additionalRow)
+            }
+
+            return Cell.fromPixelBlock(block, colorMode: colorMode)
+        }
+    }
+}


### PR DESCRIPTION
Basic `Image` view (no content mode, no resizable, etc.).

It only supports loading PPM images by path or data.

<img width="478" alt="screenshot" src="https://github.com/user-attachments/assets/32f298dd-f219-4fed-9bee-79860633e512">
